### PR TITLE
Support save-file syncing on Linux/SteamOS, including Proton

### DIFF
--- a/steam-config-reader/src/main/java/com/selesse/steam/games/SteamInstallationPaths.java
+++ b/steam-config-reader/src/main/java/com/selesse/steam/games/SteamInstallationPaths.java
@@ -11,13 +11,8 @@ public class SteamInstallationPaths {
         return switch (operatingSystem) {
             case MAC -> "~/Library/Application Support/Steam";
             case WINDOWS -> "%PROGRAMFILES(X86)%/Steam";
-            case LINUX -> "~/.steam";
-            // TODO: for Steam OS, generate path based on Windows like so:
-            // If it's SteamOS, it's:
-            // $HOME/.local/share/Steam/steamapps/compatdata/<steamlappid>/pfx/drive_c/users/steamuser/
-            // If it doesn't have Steam Auto-Cloud configured, the cloud stuff is saved in:
-            // $HOME/.steam/steam/userdata/<user id>/<steam app id>/remote
-            case STEAM_OS -> "~/.steam/steam";
+            // ~/.steam has no steamapps symlink of its own; only ~/.steam/steam does.
+            case LINUX, STEAM_OS -> "~/.steam/steam";
         };
     }
 }

--- a/steam-config-reader/src/main/java/com/selesse/steam/games/SteamInstallationPaths.java
+++ b/steam-config-reader/src/main/java/com/selesse/steam/games/SteamInstallationPaths.java
@@ -15,4 +15,9 @@ public class SteamInstallationPaths {
             case LINUX, STEAM_OS -> "~/.steam/steam";
         };
     }
+
+    public static String getProtonPrefixUserProfileRoot(long appId) {
+        return getRoot(OperatingSystems.OperatingSystem.LINUX) + "/steamapps/compatdata/" + appId
+                + "/pfx/drive_c/users/steamuser";
+    }
 }

--- a/steam-config-reader/src/main/java/com/selesse/steam/games/SteamPathConverter.java
+++ b/steam-config-reader/src/main/java/com/selesse/steam/games/SteamPathConverter.java
@@ -12,6 +12,7 @@ class SteamPathConverter {
                 .replace("MacAppSupport", "~/Library/Application Support")
                 .replace("MacDocuments", "~/Documents")
                 .replace("LinuxHome", "~")
-                .replace("LinuxXdgDataHome", System.getenv().getOrDefault("XDG_DATA_HOME", "~/.config"));
+                .replace("LinuxXdgDataHome", System.getenv().getOrDefault("XDG_DATA_HOME", "~/.local/share"))
+                .replace("LinuxXdgConfigHome", System.getenv().getOrDefault("XDG_CONFIG_HOME", "~/.config"));
     }
 }

--- a/steam-config-reader/src/main/java/com/selesse/steam/games/UserFileSystemPath.java
+++ b/steam-config-reader/src/main/java/com/selesse/steam/games/UserFileSystemPath.java
@@ -99,6 +99,12 @@ public class UserFileSystemPath {
         return recursive;
     }
 
+    public UserFileSystemPath rerootForProton(String protonPrefixUserProfileRoot) {
+        String convertedRoot = SteamPathConverter.convert(root);
+        String rerootedRoot = convertedRoot.replace("%USERPROFILE%", protonPrefixUserProfileRoot);
+        return new UserFileSystemPath(rerootedRoot, path, pattern, recursive, platform);
+    }
+
     public UserFileSystemPath convert(OperatingSystem target) {
         String root = getRoot();
         if (getRoot().equals("gameinstall")) {

--- a/steam-config-reader/src/main/java/com/selesse/steam/games/saves/EverythingInSaveFiles.java
+++ b/steam-config-reader/src/main/java/com/selesse/steam/games/saves/EverythingInSaveFiles.java
@@ -2,9 +2,12 @@ package com.selesse.steam.games.saves;
 
 import com.selesse.os.OperatingSystems;
 import com.selesse.steam.SteamApp;
+import com.selesse.steam.games.SteamInstallationPaths;
 import com.selesse.steam.games.UserFileSystemPath;
 import com.selesse.steam.games.UserFileSystemPathConverter;
+import com.selesse.steam.registry.SteamRegistry;
 import java.util.List;
+import java.util.Optional;
 
 public class EverythingInSaveFiles extends SaveFile {
     public EverythingInSaveFiles(SteamApp steamApp) {
@@ -58,8 +61,13 @@ public class EverythingInSaveFiles extends SaveFile {
                     .map(key -> ufs.getObjectValueAsObject("rootoverrides/" + key))
                     .map(RootOverrideObject::new)
                     .toList();
-            if (os == OperatingSystems.OperatingSystem.LINUX
-                    && overrides.stream().noneMatch(x -> x.getOs() == OperatingSystems.OperatingSystem.LINUX)) {
+            boolean hasExplicitLinuxOverride =
+                    overrides.stream().anyMatch(x -> x.getOs() == OperatingSystems.OperatingSystem.LINUX);
+            if (os == OperatingSystems.OperatingSystem.LINUX && !hasExplicitLinuxOverride) {
+                Optional<List<UserFileSystemPath>> protonResolved = tryResolveViaProton();
+                if (protonResolved.isPresent()) {
+                    return protonResolved.get();
+                }
                 overrides = UserFileSystemPathConverter.convertMacToLinux(overrides);
             }
             return overrides.stream()
@@ -69,6 +77,12 @@ public class EverythingInSaveFiles extends SaveFile {
                     .flatMap(List::stream)
                     .toList();
         }
+        if (os == OperatingSystems.OperatingSystem.LINUX) {
+            Optional<List<UserFileSystemPath>> protonResolved = tryResolveViaProton();
+            if (protonResolved.isPresent()) {
+                return protonResolved.get();
+            }
+        }
         if (isNonWindowsButWeOnlyHaveWindowsSaveFiles(os, saveFileObjects)) {
             return saveFileObjects.stream().map(x -> x.convert(os)).toList();
         }
@@ -76,6 +90,33 @@ public class EverythingInSaveFiles extends SaveFile {
             return saveFileObjects.stream().filter(x -> x.getPlatform() == os).toList();
         }
         return saveFileObjects;
+    }
+
+    /**
+     * A Linux/SteamOS machine running this specific game under Proton has its saves in a Windows-shaped
+     * user profile inside the compatdata prefix, not wherever the native-Linux ufs entries point. Returns
+     * empty when Proton isn't in play here, or when the Windows-target resolution isn't purely
+     * user-profile-rooted (e.g. a gameinstall-rooted save, which lives at the same path either way).
+     */
+    private Optional<List<UserFileSystemPath>> tryResolveViaProton() {
+        boolean gameHasNoNativeLinuxDepot =
+                !steamApp.getSupportedOperatingSystems().contains(OperatingSystems.OperatingSystem.LINUX);
+        boolean protonActive = SteamRegistry.getInstance().hasActiveProtonPrefix(steamApp.getId());
+        if (!protonActive && !gameHasNoNativeLinuxDepot) {
+            return Optional.empty();
+        }
+
+        List<UserFileSystemPath> windowsSavePaths = getWindowsSavePaths();
+        boolean allWinRooted = !windowsSavePaths.isEmpty()
+                && windowsSavePaths.stream().allMatch(p -> p.getRoot().startsWith("Win"));
+        if (!allWinRooted) {
+            return Optional.empty();
+        }
+
+        String protonPrefixRoot = SteamInstallationPaths.getProtonPrefixUserProfileRoot(steamApp.getId());
+        return Optional.of(windowsSavePaths.stream()
+                .map(p -> p.rerootForProton(protonPrefixRoot))
+                .toList());
     }
 
     private boolean isNonWindowsButWeOnlyHaveWindowsSaveFiles(

--- a/steam-config-reader/src/main/java/com/selesse/steam/registry/SteamRegistry.java
+++ b/steam-config-reader/src/main/java/com/selesse/steam/registry/SteamRegistry.java
@@ -5,8 +5,11 @@ import com.selesse.os.FilePathSanitizer;
 import com.selesse.os.OperatingSystems;
 import com.selesse.steam.registry.implementation.RegistryObject;
 import com.selesse.steam.registry.implementation.RegistryParser;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 public class SteamRegistry {
     public static SteamRegistry getInstance() {
@@ -35,6 +38,22 @@ public class SteamRegistry {
 
     public RegistryObject readVdf(Path path) {
         return RegistryParser.parse(RuntimeExceptionFiles.readAllLines(path));
+    }
+
+    public boolean hasActiveProtonPrefix(long appId) {
+        Path driveC = getSteamAppsPath()
+                .resolve("compatdata")
+                .resolve(String.valueOf(appId))
+                .resolve("pfx")
+                .resolve("drive_c");
+        if (!Files.isDirectory(driveC)) {
+            return false;
+        }
+        try (Stream<Path> entries = Files.list(driveC)) {
+            return entries.findAny().isPresent();
+        } catch (IOException e) {
+            return false;
+        }
     }
 
     private String getBasePath() {

--- a/steam-config-reader/src/main/java/com/selesse/steam/registry/SteamRegistry.java
+++ b/steam-config-reader/src/main/java/com/selesse/steam/registry/SteamRegistry.java
@@ -43,8 +43,8 @@ public class SteamRegistry {
             case MAC ->
                 Path.of(FilePathSanitizer.sanitize("~/Library/Application Support/Steam"))
                         .toString();
-            case LINUX -> Path.of(FilePathSanitizer.sanitize("~/.steam")).toString();
-            case STEAM_OS ->
+            // ~/.steam has no steamapps symlink of its own; only ~/.steam/steam does.
+            case LINUX, STEAM_OS ->
                 Path.of(FilePathSanitizer.sanitize("~/.steam/steam")).toString();
         };
     }

--- a/steam-config-reader/src/test/java/com/selesse/steam/games/SteamInstallationPathsTest.java
+++ b/steam-config-reader/src/test/java/com/selesse/steam/games/SteamInstallationPathsTest.java
@@ -12,4 +12,10 @@ public class SteamInstallationPathsTest {
                 .isEqualTo(SteamInstallationPaths.getRoot(OperatingSystems.OperatingSystem.STEAM_OS))
                 .isEqualTo("~/.steam/steam");
     }
+
+    @Test
+    public void getProtonPrefixUserProfileRootBuildsTheExpectedPath() {
+        assertThat(SteamInstallationPaths.getProtonPrefixUserProfileRoot(646570L))
+                .isEqualTo("~/.steam/steam/steamapps/compatdata/646570/pfx/drive_c/users/steamuser");
+    }
 }

--- a/steam-config-reader/src/test/java/com/selesse/steam/games/SteamInstallationPathsTest.java
+++ b/steam-config-reader/src/test/java/com/selesse/steam/games/SteamInstallationPathsTest.java
@@ -1,0 +1,15 @@
+package com.selesse.steam.games;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.selesse.os.OperatingSystems;
+import org.junit.Test;
+
+public class SteamInstallationPathsTest {
+    @Test
+    public void linuxAndSteamOsShareTheSameRoot() {
+        assertThat(SteamInstallationPaths.getRoot(OperatingSystems.OperatingSystem.LINUX))
+                .isEqualTo(SteamInstallationPaths.getRoot(OperatingSystems.OperatingSystem.STEAM_OS))
+                .isEqualTo("~/.steam/steam");
+    }
+}

--- a/steam-config-reader/src/test/java/com/selesse/steam/games/SteamPathConverterTest.java
+++ b/steam-config-reader/src/test/java/com/selesse/steam/games/SteamPathConverterTest.java
@@ -1,0 +1,21 @@
+package com.selesse.steam.games;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class SteamPathConverterTest {
+    @Test
+    public void convertMapsLinuxXdgDataHomeToItsSpecDefault() {
+        String expected = System.getenv().getOrDefault("XDG_DATA_HOME", "~/.local/share");
+
+        assertThat(SteamPathConverter.convert("LinuxXdgDataHome")).isEqualTo(expected);
+    }
+
+    @Test
+    public void convertMapsLinuxXdgConfigHomeToItsSpecDefault() {
+        String expected = System.getenv().getOrDefault("XDG_CONFIG_HOME", "~/.config");
+
+        assertThat(SteamPathConverter.convert("LinuxXdgConfigHome")).isEqualTo(expected);
+    }
+}

--- a/steam-config-reader/src/test/java/com/selesse/steam/games/UserFileSystemPathTest.java
+++ b/steam-config-reader/src/test/java/com/selesse/steam/games/UserFileSystemPathTest.java
@@ -22,4 +22,17 @@ public class UserFileSystemPathTest {
                         "~/Library/Application Support/Steam/steamapps/common/Torchlight II/my games/runic games/torchlight 2/save/%s/"
                                 .formatted(steamAccountId));
     }
+
+    @Test
+    public void rerootForProtonReplacesUserProfileWithTheProtonPrefix() {
+        UserFileSystemPath userFileSystemPath =
+                new UserFileSystemPath("WinAppDataLocalLow", "Team Cherry/Hollow Knight", "*.dat", false, null);
+
+        UserFileSystemPath rerooted = userFileSystemPath.rerootForProton(
+                "~/.steam/steam/steamapps/compatdata/367520/pfx/drive_c/users/steamuser");
+
+        assertThat(rerooted.getSymbolPath())
+                .isEqualTo(
+                        "~/.steam/steam/steamapps/compatdata/367520/pfx/drive_c/users/steamuser/AppData/LocalLow/Team Cherry/Hollow Knight/*.dat");
+    }
 }

--- a/steam-config-reader/src/test/java/com/selesse/steam/games/saves/EverythingInSaveFilesTest.java
+++ b/steam-config-reader/src/test/java/com/selesse/steam/games/saves/EverythingInSaveFilesTest.java
@@ -1,0 +1,167 @@
+package com.selesse.steam.games.saves;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+import com.selesse.steam.SteamApp;
+import com.selesse.steam.TestGames;
+import com.selesse.steam.games.SteamInstallationPaths;
+import com.selesse.steam.games.UserFileSystemPath;
+import com.selesse.steam.registry.SteamRegistry;
+import com.selesse.steam.registry.implementation.RegistryObject;
+import com.selesse.steam.registry.implementation.RegistryParser;
+import java.util.List;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+public class EverythingInSaveFilesTest {
+    private static final long TEST_APP_ID = 9999991L;
+
+    @Test
+    public void windowsOnlyGameWithProtonActiveResolvesUnderTheProtonPrefix() {
+        SteamApp steamApp = windowsOnlyGame();
+
+        try (MockedStatic<SteamRegistry> mocked = mockProton(true)) {
+            List<UserFileSystemPath> paths = new EverythingInSaveFiles(steamApp).getLinuxSavePaths();
+
+            assertThat(paths).hasSize(1);
+            assertThat(paths.get(0).getSymbolPath())
+                    .isEqualTo(SteamInstallationPaths.getProtonPrefixUserProfileRoot(TEST_APP_ID)
+                            + "/AppData/LocalLow/Test Game/save/*.sav");
+        }
+    }
+
+    @Test
+    public void windowsOnlyGameNeverLaunchedStillResolvesUnderTheProtonPrefix() {
+        // No native Linux depot exists at all, so Proton is the only way this game can ever run here,
+        // regardless of whether it's been launched yet (i.e. before compatdata/pfx even exists).
+        SteamApp steamApp = windowsOnlyGame();
+
+        try (MockedStatic<SteamRegistry> mocked = mockProton(false)) {
+            List<UserFileSystemPath> paths = new EverythingInSaveFiles(steamApp).getLinuxSavePaths();
+
+            assertThat(paths).hasSize(1);
+            assertThat(paths.get(0).getSymbolPath())
+                    .isEqualTo(SteamInstallationPaths.getProtonPrefixUserProfileRoot(TEST_APP_ID)
+                            + "/AppData/LocalLow/Test Game/save/*.sav");
+        }
+    }
+
+    @Test
+    public void explicitLinuxRootOverrideWinsOverProton() {
+        // Wargroove has no native Linux depot but declares an explicit Linux rootoverride
+        // (useinstead: LinuxXdgDataHome). Even with Proton "active", that explicit override must win.
+        SteamApp steamApp = realFixtureSteamApp(TestGames.WARGROOVE);
+        String xdgDataHome = System.getenv().getOrDefault("XDG_DATA_HOME", "~/.local/share");
+
+        try (MockedStatic<SteamRegistry> mocked = mockProton(true)) {
+            List<UserFileSystemPath> paths = new EverythingInSaveFiles(steamApp).getLinuxSavePaths();
+
+            assertThat(paths).hasSize(1);
+            assertThat(paths.get(0).getSymbolPath()).isEqualTo(xdgDataHome + "/Chucklefish/Wargroove/save/*");
+        }
+    }
+
+    @Test
+    public void explicitLinuxRootOverrideUsingXdgConfigHomeResolvesCorrectly() {
+        // Regression test for the real Rogue Legacy 2 bug: an explicit rootoverride using
+        // "LinuxXdgConfigHome" used to pass through SteamPathConverter unconverted. Also proves
+        // this explicit override wins over Proton, exactly like the Wargroove case above.
+        SteamApp steamApp = gameWithLinuxXdgConfigHomeOverride();
+        String xdgConfigHome = System.getenv().getOrDefault("XDG_CONFIG_HOME", "~/.config");
+
+        try (MockedStatic<SteamRegistry> mocked = mockProton(true)) {
+            List<UserFileSystemPath> paths = new EverythingInSaveFiles(steamApp).getLinuxSavePaths();
+
+            assertThat(paths).hasSize(1);
+            assertThat(paths.get(0).getSymbolPath()).isEqualTo(xdgConfigHome + "/unity3d/TestCo/Test Game/Saves/*");
+        }
+    }
+
+    @Test
+    public void gameInstallRootedSaveIsUnaffectedByProton() {
+        // Inscryption's saves live inside the install directory itself, which is the same real
+        // directory on disk whether Steam installed the Windows or Linux depot there.
+        SteamApp steamApp = realFixtureSteamApp(TestGames.INSCRYPTION);
+
+        try (MockedStatic<SteamRegistry> mocked = mockProton(true)) {
+            List<UserFileSystemPath> paths = new EverythingInSaveFiles(steamApp).getLinuxSavePaths();
+
+            assertThat(paths).hasSize(1);
+            assertThat(paths.get(0).getRoot()).doesNotContain("compatdata");
+        }
+    }
+
+    private MockedStatic<SteamRegistry> mockProton(boolean active) {
+        SteamRegistry steamRegistry = Mockito.mock(SteamRegistry.class);
+        when(steamRegistry.hasActiveProtonPrefix(anyLong())).thenReturn(active);
+        MockedStatic<SteamRegistry> mocked = Mockito.mockStatic(SteamRegistry.class);
+        mocked.when(SteamRegistry::getInstance).thenReturn(steamRegistry);
+        return mocked;
+    }
+
+    private SteamApp windowsOnlyGame() {
+        List<String> lines = List.of(
+                "\"common\"",
+                "{",
+                "\t\"gameid\"\t\"" + TEST_APP_ID + "\"",
+                "\t\"name\"\t\"Test Game\"",
+                "\t\"oslist\"\t\"windows\"",
+                "}",
+                "\"ufs\"",
+                "{",
+                "\t\"savefiles\"",
+                "\t{",
+                "\t\t\"0\"",
+                "\t\t{",
+                "\t\t\t\"root\"\t\"WinAppDataLocalLow\"",
+                "\t\t\t\"path\"\t\"Test Game/save\"",
+                "\t\t\t\"pattern\"\t\"*.sav\"",
+                "\t\t}",
+                "\t}",
+                "}");
+        return new SteamApp(RegistryParser.parseWithoutRegistryCollapse(lines));
+    }
+
+    private SteamApp gameWithLinuxXdgConfigHomeOverride() {
+        List<String> lines = List.of(
+                "\"common\"",
+                "{",
+                "\t\"gameid\"\t\"" + TEST_APP_ID + "\"",
+                "\t\"name\"\t\"Test Game\"",
+                "\t\"oslist\"\t\"windows,linux\"",
+                "}",
+                "\"ufs\"",
+                "{",
+                "\t\"savefiles\"",
+                "\t{",
+                "\t\t\"0\"",
+                "\t\t{",
+                "\t\t\t\"root\"\t\"WinAppDataLocalLow\"",
+                "\t\t\t\"path\"\t\"TestCo/Test Game/Saves\"",
+                "\t\t\t\"pattern\"\t\"*\"",
+                "\t\t}",
+                "\t}",
+                "\t\"rootoverrides\"",
+                "\t{",
+                "\t\t\"0\"",
+                "\t\t{",
+                "\t\t\t\"root\"\t\"WinAppDataLocalLow\"",
+                "\t\t\t\"os\"\t\"Linux\"",
+                "\t\t\t\"oscompare\"\t\"=\"",
+                "\t\t\t\"useinstead\"\t\"LinuxXdgConfigHome\"",
+                "\t\t\t\"addpath\"\t\"unity3d\"",
+                "\t\t}",
+                "\t}",
+                "}");
+        RegistryObject registryObject = RegistryParser.parseWithoutRegistryCollapse(lines);
+        return new SteamApp(registryObject);
+    }
+
+    private SteamApp realFixtureSteamApp(TestGames testGame) {
+        RegistryObject registryObject = RegistryParser.parse(testGame.registryFileContentsFromFile());
+        return new SteamApp(registryObject);
+    }
+}

--- a/steam-config-reader/src/test/java/com/selesse/steam/registry/SteamRegistryTest.java
+++ b/steam-config-reader/src/test/java/com/selesse/steam/registry/SteamRegistryTest.java
@@ -1,12 +1,16 @@
 package com.selesse.steam.registry;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
 
 import com.selesse.os.Resources;
 import com.selesse.steam.registry.implementation.RegistryObject;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public class SteamRegistryTest {
     @Test
@@ -40,5 +44,38 @@ public class SteamRegistryTest {
 
         assertThat(result).isPresent();
         assertThat(result.get().pathExists("users")).isTrue();
+    }
+
+    @Test
+    public void hasActiveProtonPrefixIsFalseWhenCompatDataIsMissing() throws IOException {
+        Path steamApps = Files.createTempDirectory("steamapps");
+        SteamRegistry steamRegistry = spyOnSteamApps(steamApps);
+
+        assertThat(steamRegistry.hasActiveProtonPrefix(646570L)).isFalse();
+    }
+
+    @Test
+    public void hasActiveProtonPrefixIsFalseWhenDriveCIsEmpty() throws IOException {
+        Path steamApps = Files.createTempDirectory("steamapps");
+        Files.createDirectories(steamApps.resolve("compatdata/646570/pfx/drive_c"));
+        SteamRegistry steamRegistry = spyOnSteamApps(steamApps);
+
+        assertThat(steamRegistry.hasActiveProtonPrefix(646570L)).isFalse();
+    }
+
+    @Test
+    public void hasActiveProtonPrefixIsTrueWhenDriveCHasContent() throws IOException {
+        Path steamApps = Files.createTempDirectory("steamapps");
+        Path driveC = steamApps.resolve("compatdata/646570/pfx/drive_c");
+        Files.createDirectories(driveC.resolve("users/steamuser"));
+        SteamRegistry steamRegistry = spyOnSteamApps(steamApps);
+
+        assertThat(steamRegistry.hasActiveProtonPrefix(646570L)).isTrue();
+    }
+
+    private SteamRegistry spyOnSteamApps(Path steamApps) {
+        SteamRegistry steamRegistry = Mockito.spy(SteamRegistry.getInstance());
+        doReturn(steamApps).when(steamRegistry).getSteamAppsPath();
+        return steamRegistry;
     }
 }

--- a/steam-config-reader/src/test/resources/game-installation-paths.yml
+++ b/steam-config-reader/src/test/resources/game-installation-paths.yml
@@ -12,7 +12,7 @@ games:
   mac:
     - "~/Library/Application Support/Steam/steamapps/common/The Jackbox Party Pack/save/*.sav"
   linux:
-    - "~/.steam/steamapps/common/The Jackbox Party Pack/save/*.sav"
+    - "~/.steam/steam/steamapps/common/The Jackbox Party Pack/save/*.sav"
 - name: "Inscryption"
   windows:
     - "%PROGRAMFILES(X86)%/Steam/steamapps/common/Inscryption/*.gwsave"
@@ -38,9 +38,9 @@ games:
     - "~/Library/Application Support/Steam/steamapps/common/SlayTheSpire/SlayTheSpire.app/Contents/Resources/betaPreferences/*"
     - "~/Library/Application Support/Steam/steamapps/common/SlayTheSpire/SlayTheSpire.app/Contents/Resources/saves/*"
   linux:
-    - "~/.steam/steamapps/common/SlayTheSpire/preferences/*"
-    - "~/.steam/steamapps/common/SlayTheSpire/betaPreferences/*"
-    - "~/.steam/steamapps/common/SlayTheSpire/saves/*"
+    - "~/.steam/steam/steamapps/common/SlayTheSpire/preferences/*"
+    - "~/.steam/steam/steamapps/common/SlayTheSpire/betaPreferences/*"
+    - "~/.steam/steam/steamapps/common/SlayTheSpire/saves/*"
 - name: "Unrailed!"
   windows:
     - "%USERPROFILE%/AppData/Local/Daedalic Entertainment GmbH/Unrailed/GameState/AllPlayers/SaveGames/*.sav"
@@ -57,7 +57,7 @@ games:
   mac:
     - "~/Library/Application Support/Steam/steamapps/common/Wildermyth/wildermyth.app/Contents/Resources/players/*"
   linux:
-    - "~/.steam/steamapps/common/Wildermyth/players/*"
+    - "~/.steam/steam/steamapps/common/Wildermyth/players/*"
 - name: "Pillars of Eternity"
   windows:
     - "%USERPROFILE%/Saved Games/Pillars of Eternity/*.savegame"

--- a/steam-config-reader/src/test/resources/game-installation-paths.yml
+++ b/steam-config-reader/src/test/resources/game-installation-paths.yml
@@ -64,7 +64,7 @@ games:
   mac:
     - "~/Library/Application Support/Pillars of Eternity/*.savegame"
   linux:
-    - "~/.config/PillarsOfEternity/*.savegame"
+    - "~/.local/share/PillarsOfEternity/*.savegame"
 - name: "Avadon: The Black Fortress"
   windows:
     - "%USERPROFILE%/Documents/Spiderweb Software/Avadon Saved Games/Save0/*"


### PR DESCRIPTION
Fixes https://github.com/selesse/steam-crossplatform-sync/issues/2

A Linux/SteamOS install of a game is either a native Linux depot or the Windows depot running under Proton in a per-appid Wine prefix, and that's not derivable from the game's declared platforms — Steam can run a title via Proton even when a native Linux build is also installed. [`SteamRegistry.hasActiveProtonPrefix`](https://github.com/selesse/steam-crossplatform-sync/blob/106554f29493b36b7f0607859688cfb99800cfc1/steam-config-reader/src/main/java/com/selesse/steam/registry/SteamRegistry.java#L43-L57) uses `compatdata/<appId>/pfx/drive_c` being populated as ground truth for which one applies, since that's what Steam actually creates when it launches something through Proton, regardless of what's merely installed or declared.

[`EverythingInSaveFiles.tryResolveViaProton`](https://github.com/selesse/steam-crossplatform-sync/blob/258f0a4f5d2a6aab613d98d95acdc8029313e3f5/steam-config-reader/src/main/java/com/selesse/steam/games/saves/EverythingInSaveFiles.java#L101-L119) re-roots `Win*`-rooted save paths at the compat prefix (`UserFileSystemPath.rerootForProton`) instead of resolving them as native Linux paths. An explicit Linux `rootoverride` always wins over this (see `WARGROOVE` test case) — Proton-reroot only replaces the fallback paths that previously produced wrong output, not deliberate per-game config. `gameinstall`-rooted saves are untouched either way, since that directory is the same on disk regardless of which depot Steam installed.

Also fixes three bugs in `LINUX`-target path resolution that predate Proton and aren't Deck-specific — they'd affect any desktop Linux user running these games under Proton too:
- `SteamPathConverter` had no mapping for the `LinuxXdgConfigHome` root token (a common Unity save-path convention), so it passed through unconverted.
- `LinuxXdgDataHome` defaulted to `~/.config` when unset — that's the spec default for `XDG_CONFIG_HOME`, not `XDG_DATA_HOME`.
- `SteamInstallationPaths.getRoot(LINUX)` and `SteamRegistry.getBasePath()` both returned `~/.steam`, which has no `steamapps` symlink of its own — only `~/.steam/steam` does.

Two more bugs in the same code path (a Mac→Linux `rootoverrides` fallback that mislabels without translating, and single-OS games missing a `platforms` tag returning a raw unconverted Windows path) are left as dead code rather than fixed directly: every game that hits either branch has no native Linux depot at all, so there's no native-Linux path for them to resolve to — Proton-reroot is the only answer that can ever be correct, which is exactly what now runs instead.

Not in scope: the issue also asks for provider-agnostic cloud drive support. `CloudStorageProvider` already exists as an interface, but `GoogleDriveProvider` has no real Linux auto-detection — untouched here.